### PR TITLE
Restore workplace after script loop

### DIFF
--- a/AFKProcessing.ahk
+++ b/AFKProcessing.ahk
@@ -10,13 +10,16 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 total_loops := 0 ; variabe to count how many times the loop was executed
 
 ifWinNotExist, METAL GEAR SOLID V: THE PHANTOM PAIN ; checks if MGSV-TPP is opened
+{
 	MsgBox, 0, Error - MSGV: TPP not found, METAL GEAR SOLID V: THE PHANTOM PAIN not found. Please start it before launching AFKProcessing.
-	
+	ExitApp
+}
 Settimer, Instructions, 720000 ; calls "Instructions" every ~12 Minutes (Material Processing Rank B)
 Gosub Instructions ; to start the first loop immediately if wanted
 return
 
 Instructions:
+WinGetActiveTitle, old_window ; saves the currently active window
 IfWinNotActive, METAL GEAR SOLID V: THE PHANTOM PAIN ; activates MGSV-TPP if not already active
 	WinActivate, METAL GEAR SOLID V: THE PHANTOM PAIN
 WinWaitActive, METAL GEAR SOLID V: THE PHANTOM PAIN ; waits till MGSV-TPP is active
@@ -24,11 +27,12 @@ Send, {Tab}
 Sleep, 1000 ; needs optimization for slower/(faster) PCs
 Send, {Tab}
 Sleep, 100
+WinActivate, %old_window% ; restores the active window before the loop was executed
 total_loops := total_loops + 1 ; loop count up
 return	
 
 ^!m:: ; hotkey to end the script
 {
-	MsgBox, 4096, AFKProcessing was Stopped, A total of %total_loops% material processes were made.
+	MsgBox, 4096, AFKProcessing was stopped, You have stopped AFKProcessing by pressing the hotkey. `n`nA total of %total_loops% material processes were made.
 	ExitApp
 }

--- a/AFKProcessing.ahk
+++ b/AFKProcessing.ahk
@@ -2,13 +2,14 @@
 ; #Warn  ; Enable warnings to assist with detecting common errors.
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
-#SingleInstance, Force
-#NoTrayIcon
-#Persistent
 
-total_loops := 0
+#SingleInstance, Force ; when a new instance of the script is started the old one is closed
+#NoTrayIcon ; no green "H"-icon in the tray
+#Persistent ; not necessarily needed because script contains a hotkey
 
-ifWinNotExist, METAL GEAR SOLID V: THE PHANTOM PAIN
+total_loops := 0 ; variabe to count how many times the loop was executed
+
+ifWinNotExist, METAL GEAR SOLID V: THE PHANTOM PAIN ; checks if MGSV-TPP is opened
 	MsgBox, 0, Error - MSGV: TPP not found, METAL GEAR SOLID V: THE PHANTOM PAIN not found. Please start it before launching AFKProcessing.
 	
 Settimer, Instructions, 720000 ; calls "Instructions" every ~12 Minutes (Material Processing Rank B)
@@ -16,17 +17,17 @@ Gosub Instructions ; to start the first loop immediately if wanted
 return
 
 Instructions:
-IfWinNotActive, METAL GEAR SOLID V: THE PHANTOM PAIN
+IfWinNotActive, METAL GEAR SOLID V: THE PHANTOM PAIN ; activates MGSV-TPP if not already active
 	WinActivate, METAL GEAR SOLID V: THE PHANTOM PAIN
-WinWaitActive, METAL GEAR SOLID V: THE PHANTOM PAIN
+WinWaitActive, METAL GEAR SOLID V: THE PHANTOM PAIN ; waits till MGSV-TPP is active
 Send, {Tab}
-Sleep, 1000
+Sleep, 1000 ; needs optimization for slower/(faster) PCs
 Send, {Tab}
 Sleep, 100
-total_loops := total_loops + 1
+total_loops := total_loops + 1 ; loop count up
 return	
 
-^!m::
+^!m:: ; hotkey to end the script
 {
 	MsgBox, 4096, AFKProcessing was Stopped, A total of %total_loops% material processes were made.
 	ExitApp


### PR DESCRIPTION
General:
- updated message boxes
- updated documentation
  Features:
- the window which was active before the loop executes is now reactivated after the loop finishes
  Bugfixes:
- if MGSV-TPP is not opened the script will now close instead of continuing to run
